### PR TITLE
Add a default Firmware option if not set in the xva image builds.

### DIFF
--- a/builder/xenserver/xva/builder.go
+++ b/builder/xenserver/xva/builder.go
@@ -61,6 +61,10 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, warns []stri
 		self.config.VMMemory = 1024
 	}
 
+	if self.config.Firmware == "" {
+		self.config.Firmware = "bios"
+	}
+
 	if len(self.config.PlatformArgs) == 0 {
 		pargs := make(map[string]string)
 		pargs["viridian"] = "false"


### PR DESCRIPTION
The default option of bios was set in iso builds but not in xva. This would result in the following error when trying to clone a vm off of the template when using xapi json rpc

`{"code":"INVALID_VALUE","params":["HVM-boot-params['firmware']",""]` 

firmware was an empty string. Adding a default results in firmware='bios'